### PR TITLE
Updates and fixes to the descriptions of some script editors and a fixed typo in LPlayerData.

### DIFF
--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/LSceneObjectEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/LSceneObjectEditor.cs
@@ -114,6 +114,8 @@ public class LSceneObjectEditor : ModBaseEditor
 
 		EditorGUILayout.PropertyField(rotation);
 
+		EditorGUILayout.PropertyField(scale);
+
 		GUI.enabled = false;
 
 		EditorGUILayout.PropertyField(parentTransform);

--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModMagicEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModMagicEditor.cs
@@ -15,7 +15,7 @@ public class ModMagicEditor : ModBaseEditor
 	public SerializedProperty element;
 	public SerializedProperty chargeTime;
 	public SerializedProperty minChargeTime;
-	public SerializedProperty lifeCost;
+	public SerializedProperty projectileLifetime;
 	public SerializedProperty manaCost;
 	public SerializedProperty colour;
 	public SerializedProperty fadeSpeed;
@@ -39,7 +39,7 @@ public class ModMagicEditor : ModBaseEditor
 		element = serializedObject.FindProperty("MAG_ELEM");
 		chargeTime = serializedObject.FindProperty("MAG_CHARGE_TIME");
 		minChargeTime = serializedObject.FindProperty("MIN_CHARGE_TIME");
-		lifeCost = serializedObject.FindProperty("MAG_LIFE");
+		projectileLifetime = serializedObject.FindProperty("MAG_LIFE");
 		manaCost = serializedObject.FindProperty("MAG_COST");
 		fadeSpeed = serializedObject.FindProperty("MAG_FADE");
 		isBlood = serializedObject.FindProperty("MAG_BL");
@@ -68,8 +68,8 @@ public class ModMagicEditor : ModBaseEditor
 
 		EditorTools.DrawHelpProperty(chargeTime, "How long the magic takes to charge to cast.");
 		EditorTools.DrawHelpProperty(minChargeTime, "The shortest the charge time can become after bonuses from player stats.");
-		EditorTools.DrawHelpProperty(lifeCost, "The health cost to cast the magic (blood magic only).");
-		EditorTools.DrawHelpProperty(manaCost, "The mana cost to cast the magic (non-blood magic only).");
+		EditorTools.DrawHelpProperty(projectileLifetime, "The duration (in seconds) the projectile will exist for.");
+		EditorTools.DrawHelpProperty(manaCost, "The mana or health cost to cast the magic.");
 		EditorTools.DrawHelpProperty(fadeSpeed, "The speed to fade the casting flash.");
 		EditorTools.DrawHelpProperty(isBlood, "If the magic is considered a blood magic.");
 

--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModMagicEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModMagicEditor.cs
@@ -27,7 +27,7 @@ public class ModMagicEditor : ModBaseEditor
 	private void OnEnable()
 	{
 		magicTypes = typeof(Lunatic.MagicTypes).GetEnumNames();
-		elementTypes = typeof(Lunatic.Elements).GetEnumNames();
+		elementTypes = typeof(Lunatic.ElementIcons).GetEnumNames();
 
 		projectile = serializedObject.FindProperty("projectile");
 		projectileName = serializedObject.FindProperty("MAG_CHILD");
@@ -51,7 +51,7 @@ public class ModMagicEditor : ModBaseEditor
 		DrawProjectile(projectile, projectileName, "The object to spawn on cast.");
 
 		EditorTools.DrawHelpProperty(description, "The description shown in the player's inventory.");
-		EditorTools.DrawHelpProperty(icon, "The sprite shown in the player's inventory and in the active quick item hotbar.");
+		EditorTools.DrawHelpProperty(icon, "The sprite shown on the user interface.");
 		EditorTools.DrawHelpProperty(colour, "The colour to tint the icon.");
 
 		if (EditorTools.ShowHelp)
@@ -59,14 +59,14 @@ public class ModMagicEditor : ModBaseEditor
 
 		type.intValue = EditorGUILayout.Popup(type.displayName, type.intValue, magicTypes);
 
-		EditorTools.DrawHelpProperty(damage, "How much damage the magic projectile inflicts.");
+		EditorTools.DrawHelpProperty(damage, "How much damage the magic projectile inflicts by default.");
 
 		if (EditorTools.ShowHelp)
-			EditorGUILayout.HelpBox("The damage type element of the magic.", MessageType.Info);
+			EditorGUILayout.HelpBox("The element icon displayed on the menu (note that the actual damage type is determined by the damage_trigger on the projectile).", MessageType.Info);
 
 		element.intValue = EditorGUILayout.Popup(element.displayName, element.intValue, elementTypes);
 
-		EditorTools.DrawHelpProperty(chargeTime, "How long the magic takes to charge to cast.");
+		EditorTools.DrawHelpProperty(chargeTime, "How long the magic takes to charge by default.");
 		EditorTools.DrawHelpProperty(minChargeTime, "The shortest the charge time can become after bonuses from player stats.");
 		EditorTools.DrawHelpProperty(projectileLifetime, "The duration (in seconds) the projectile will exist for.");
 		EditorTools.DrawHelpProperty(manaCost, "The mana or health cost to cast the magic.");

--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
@@ -40,6 +40,7 @@ public class ModWeaponEditor : ModBaseEditor
 
 	private void OnEnable()
 	{
+		elementTypes = typeof(Lunatic.ElementIcons).GetEnumNames();
 		glove = serializedObject.FindProperty("Glove");
 		attackAnims = serializedObject.FindProperty("Attack_Anims");
 		blockAnims = serializedObject.FindProperty("Block_Anims");

--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
@@ -139,7 +139,7 @@ public class ModWeaponEditor : ModBaseEditor
 			EditorTools.DrawHelpProperty(damage, "How much damage the weapon inflicts on hit.");
 			EditorTools.DrawHelpProperty(reach, "How far the weapon attack reaches.");
 			if (EditorTools.ShowHelp)
-				EditorGUILayout.HelpBox("The elemental type of the weapon's damage. Note that values 6 & 7 have no effect.", MessageType.Info);
+				EditorGUILayout.HelpBox("The elemental type of the weapon's damage. Note that blood and random have no effect.", MessageType.Info);
 			element.intValue = EditorGUILayout.Popup(element.displayName, element.intValue, elementTypes);
 			EditorTools.DrawHelpProperty(chargeSpeed, "How long the attack button must be held before fully charging the weapon attack.");
 			EditorTools.DrawHelpProperty(swingCooldown, "Delay between each swing of the weapon.");

--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
@@ -136,7 +136,9 @@ public class ModWeaponEditor : ModBaseEditor
 			EditorTools.DrawHelpProperty(type, "The attack style of the weapon.");
 			EditorTools.DrawHelpProperty(damage, "How much damage the weapon inflicts on hit.");
 			EditorTools.DrawHelpProperty(reach, "How far the weapon attack reaches.");
-			EditorTools.DrawHelpProperty(element, "The element of the weapon to use for damage calculations.");
+			if (EditorTools.ShowHelp)
+				EditorGUILayout.HelpBox("The elemental type of the weapon's damage. Note that values 6 & 7 have no effect.", MessageType.Info);
+			element.intValue = EditorGUILayout.Popup(element.displayName, element.intValue, elementTypes);
 			EditorTools.DrawHelpProperty(chargeSpeed, "How long the attack button must be held before fully charging the weapon attack.");
 			EditorTools.DrawHelpProperty(swingCooldown, "Delay between each swing of the weapon.");
 			EditorTools.DrawHelpProperty(attackAnims, "Animations to use for the attacking combo chain.");

--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
@@ -8,8 +8,9 @@ public class ModWeaponEditor : ModBaseEditor
 	private bool idle = true;
 	private bool attack = true;
 	private bool block = true;
+	private string[] elementTypes;
 
-    private SerializedProperty glove;
+	private SerializedProperty glove;
     private SerializedProperty attackAnims;
     private SerializedProperty blockAnims;
     private SerializedProperty idleAnim;

--- a/Packages/com.empiodavion.lunatic@1.0.0/Scripts/LPlayerData.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Scripts/LPlayerData.cs
@@ -97,7 +97,7 @@ internal class LPlayerData
 				weapon1 = Lunatic.FindModFromInternalName(playerData.WEP1),
 				weapon2 = Lunatic.FindModFromInternalName(playerData.WEP2),
 				magic1 = Lunatic.FindModFromInternalName(playerData.MAG1),
-				magic2 = Lunatic.FindModFromInternalName(playerData.MAG1),
+				magic2 = Lunatic.FindModFromInternalName(playerData.MAG2),
 				item1 = Lunatic.FindModFromInternalName(playerData.ITEM1),
 				item2 = Lunatic.FindModFromInternalName(playerData.ITEM2),
 				item3 = Lunatic.FindModFromInternalName(playerData.ITEM3),

--- a/Packages/com.empiodavion.lunatic@1.0.0/Scripts/Lunatic.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Scripts/Lunatic.cs
@@ -110,6 +110,22 @@ public static class Lunatic
 		DarkFire
 	}
 
+	public enum ElementIcons
+	{
+		Normal,
+		Fire,
+		Ice,
+		Poison,
+		Light,
+		Dark,
+		Blood,
+		Random,
+		DarkLight,
+		NormalFire,
+		IcePoison,
+		DarkFire
+	}
+
 	public enum WeaponTypes
 	{
 		Melee,


### PR DESCRIPTION
The MAG_LIFE property had an incorrect description. It stated that MAG_LIFE was the blood cost of a spell, whereas it is in fact an override for the Auto_Kill component of a spell's projectile. Additionally, the element descriptions were somewhat inaccurate. A spell's MAG_ELEM property has no impact at all on the projectile, and only affects the icon in the inventory. The dropdown for selecting MAG_ELEM also lacked Poison and Random, so I changed it to use a seperate set which includes them. I also made the weapon script's element select use the same dropdown with an added note that blood and random do not work for weapons.