### PR TITLE
Make un-usable items work.

### DIFF
--- a/Packages/com.empiodavion.lunatic@1.0.0/Scripts/Mod.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Scripts/Mod.cs
@@ -166,6 +166,7 @@ public class Mod : ScriptableObject
 		{
 			Lunatic.FixShaders(item);
 			Lunatic.TrackItem(item);
+			item.Init();
 		}
 
 		Lunatic.ModItems.AddRange(items);

--- a/Packages/com.empiodavion.lunatic@1.0.0/Scripts/ModItem.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Scripts/ModItem.cs
@@ -6,9 +6,13 @@
 	public string AssetName { get; set; }
 	public string InternalName => Lunatic.GetInternalName(this);
 
-	// TODO: Supply code for GetCastObject
+    // TODO: Supply code for GetCastObject
+    internal void Init()
+    {
+        ITEM_NAME = InternalName;
+    }
 
-	public virtual void OnUse()
+    public virtual void OnUse()
 	{
 
 	}


### PR DESCRIPTION
minor hack to get Usable_Item.TakeOne() to work - nothing written to make using the item work.