### PR TITLE
Fix to ModWeaponEditor description

### DIFF
--- a/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
+++ b/Packages/com.empiodavion.lunatic@1.0.0/Editor/Lunatic/ModWeaponEditor.cs
@@ -139,7 +139,7 @@ public class ModWeaponEditor : ModBaseEditor
 			EditorTools.DrawHelpProperty(damage, "How much damage the weapon inflicts on hit.");
 			EditorTools.DrawHelpProperty(reach, "How far the weapon attack reaches.");
 			if (EditorTools.ShowHelp)
-				EditorGUILayout.HelpBox("The elemental type of the weapon's damage. Note that blood and random have no effect.", MessageType.Info);
+				EditorGUILayout.HelpBox("The elemental type of the weapon's damage. Note that blood and random have no effect on melee weapons. On ranged weapons this does not affect the damage type of the projectile, only the type displayed in the menu. To change their element, change the element on the damage_trigger of the projectile.", MessageType.Info);
 			element.intValue = EditorGUILayout.Popup(element.displayName, element.intValue, elementTypes);
 			EditorTools.DrawHelpProperty(chargeSpeed, "How long the attack button must be held before fully charging the weapon attack.");
 			EditorTools.DrawHelpProperty(swingCooldown, "Delay between each swing of the weapon.");


### PR DESCRIPTION
Fixed element description, as I forgot it was for ranged weapons too.